### PR TITLE
Change shape implementation to maximize EBO opportunities

### DIFF
--- a/include/kwk/container/shape.hpp
+++ b/include/kwk/container/shape.hpp
@@ -126,8 +126,8 @@ namespace kwk
     //==============================================================================================
     KWK_FORCEINLINE constexpr shape() noexcept
     {
-      if constexpr(storage_size > 1ULL)  for(auto& e : as_array()) e = 1;
-      if constexpr(storage_size > 0ULL)  as_array()[0] = 0;
+      if constexpr(storage_size > 1ULL)  for(auto& e : storage()) e = 1;
+      if constexpr(storage_size > 0ULL)  storage()[0] = 0;
     }
 
     //==============================================================================================
@@ -151,7 +151,7 @@ namespace kwk
     {
       if constexpr(sizeof...(T) < static_order)
         for(std::size_t i = sizeof...(T);i<static_order;++i)
-          as_array()[i] = 1;
+          storage()[i] = 1;
     }
 
     //==============================================================================================
@@ -180,8 +180,8 @@ namespace kwk
         {
           if constexpr(!size_map::contains(I))
           {
-            if constexpr(I==0)  as_array()[size_map::template locate<static_order>(I)] = 0;
-            else                as_array()[size_map::template locate<static_order>(I)] = 1;
+            if constexpr(I==0)  storage()[size_map::template locate<static_order>(I)] = 0;
+            else                storage()[size_map::template locate<static_order>(I)] = 1;
           }
         }
       );
@@ -193,7 +193,7 @@ namespace kwk
                       , "[kwk::shape] Semi-dynamic construction overwrite static shape"
                       );
 
-        as_array()[size_map::template locate<static_order>(e.dims)] = static_cast<size_type>(e.size);
+        storage()[size_map::template locate<static_order>(e.dims)] = static_cast<size_type>(e.size);
       };
 
       (fill(s),...);
@@ -224,7 +224,7 @@ namespace kwk
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
           constexpr auto idx = size_map::template locate<static_order>(I);
-          if constexpr( idx < storage_size ) as_array()[idx] = other.template get<I>();
+          if constexpr( idx < storage_size ) storage()[idx] = other.template get<I>();
         }
       );
     }
@@ -251,11 +251,11 @@ namespace kwk
       detail::constexpr_for<dz>
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
-          as_array()[I] = other.template get<I>();
+          storage()[I] = other.template get<I>();
         }
       );
 
-      for(std::size_t i = dz; i < static_order;++i) as_array()[i] = 1;
+      for(std::size_t i = dz; i < static_order;++i) storage()[i] = 1;
     }
 
     //==============================================================================================
@@ -281,14 +281,14 @@ namespace kwk
       detail::constexpr_for<dz>
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
-          as_array()[I] = other.template get<I>();
+          storage()[I] = other.template get<I>();
         }
       );
 
       detail::constexpr_for<shape<OtherShaper>::static_order - dz>
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
-          as_array().back() *= other.template get<dz+I>();
+          storage().back() *= other.template get<dz+I>();
         }
       );
     }
@@ -312,13 +312,13 @@ namespace kwk
     template<std::size_t I> constexpr auto get() const noexcept
     {
       if constexpr(size_map::contains(I)) return Shaper.at(I);
-      else return as_array()[size_map::template locate<static_order>(I)];
+      else return storage()[size_map::template locate<static_order>(I)];
     }
 
     /// Swap shape's contents
     void swap( shape& other ) noexcept
     {
-      as_array().swap( other.as_array() );
+      storage().swap( other.storage() );
     }
 
 /*
@@ -424,8 +424,8 @@ namespace kwk
       return os;
     }
 
-    constexpr storage_t&        as_array() noexcept       { return static_cast<storage_t&>(*this);        }
-    constexpr storage_t const&  as_array() const noexcept { return static_cast<storage_t const&>(*this);  }
+    constexpr storage_t&        storage() noexcept       { return static_cast<storage_t&>(*this);        }
+    constexpr storage_t const&  storage() const noexcept { return static_cast<storage_t const&>(*this);  }
 
     private:
 

--- a/include/kwk/container/shape.hpp
+++ b/include/kwk/container/shape.hpp
@@ -23,6 +23,24 @@ namespace kwk
 {
   struct size_;
 
+  namespace detail
+  {
+    // Compute the shape base class for storage
+    template<auto Shaper> struct shape_storage
+    {
+      using size_map                                = decltype(Shaper.size_map());
+      static constexpr std::ptrdiff_t static_order  = Shaper.size();
+      using size_type                               = typename decltype(Shaper)::size_type;
+
+      struct empty_storage {};
+      static constexpr std::ptrdiff_t storage_size  = static_order - size_map::size;
+      using type  = std::conditional_t< (storage_size!=0)
+                                      , std::array<size_type,storage_size>
+                                      , empty_storage
+                                      >;
+    };
+  }
+
   //================================================================================================
   //! @ingroup containers
   //! @brief  Fixed order shape with mixed size capability
@@ -66,22 +84,19 @@ namespace kwk
   //!
   //! @tparam Shaper An instance of an shape descriptor
   //================================================================================================
-  template<auto Shaper> struct shape
+  template<auto Shaper>
+  struct shape : detail::shape_storage<Shaper>::type
   {
-    using size_map      = decltype(Shaper.size_map());
+    using parent    = detail::shape_storage<Shaper>;
+    using size_map  = typename parent::size_map;
 
     /// @ref glossary-order of the eve::shape
     static constexpr std::ptrdiff_t static_order = Shaper.size();
+    static constexpr std::ptrdiff_t storage_size  = parent::storage_size;
 
     /// Type of dimensions' size
-    using size_type     = typename decltype(Shaper)::size_type;
-
-    struct empty_storage {};
-    static constexpr std::ptrdiff_t storage_size  = static_order - size_map::size;
-    using storage_t     = std::conditional_t< (storage_size!=0)
-                                            , std::array<size_type,storage_size>
-                                            , empty_storage
-                                            >;
+    using size_type     = typename parent::size_type;
+    using storage_t     = typename parent::type;
 
     /// Associated kwk::stride type
     using stride_type   = unit_stride<size_type, static_order>;
@@ -111,8 +126,8 @@ namespace kwk
     //==============================================================================================
     KWK_FORCEINLINE constexpr shape() noexcept
     {
-      if constexpr(storage_size > 1ULL)  for(auto& e : storage_) e = 1;
-      if constexpr(storage_size > 0ULL)  storage_[0] = 0;
+      if constexpr(storage_size > 1ULL)  for(auto& e : as_array()) e = 1;
+      if constexpr(storage_size > 0ULL)  as_array()[0] = 0;
     }
 
     //==============================================================================================
@@ -132,11 +147,11 @@ namespace kwk
               &&  (sizeof...(T) <= static_order)
               &&  is_fully_dynamic
               )
-            : storage_{ static_cast<size_type>(s)... }
+            : storage_t{ static_cast<size_type>(s)... }
     {
       if constexpr(sizeof...(T) < static_order)
         for(std::size_t i = sizeof...(T);i<static_order;++i)
-          storage_[i] = 1;
+          as_array()[i] = 1;
     }
 
     //==============================================================================================
@@ -165,8 +180,8 @@ namespace kwk
         {
           if constexpr(!size_map::contains(I))
           {
-            if constexpr(I==0)  storage_[size_map::template locate<static_order>(I)] = 0;
-            else                storage_[size_map::template locate<static_order>(I)] = 1;
+            if constexpr(I==0)  as_array()[size_map::template locate<static_order>(I)] = 0;
+            else                as_array()[size_map::template locate<static_order>(I)] = 1;
           }
         }
       );
@@ -178,7 +193,7 @@ namespace kwk
                       , "[kwk::shape] Semi-dynamic construction overwrite static shape"
                       );
 
-        storage_[size_map::template locate<static_order>(e.dims)] = static_cast<size_type>(e.size);
+        as_array()[size_map::template locate<static_order>(e.dims)] = static_cast<size_type>(e.size);
       };
 
       (fill(s),...);
@@ -209,7 +224,7 @@ namespace kwk
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
           constexpr auto idx = size_map::template locate<static_order>(I);
-          if constexpr( idx < storage_size ) storage_[idx] = other.template get<I>();
+          if constexpr( idx < storage_size ) as_array()[idx] = other.template get<I>();
         }
       );
     }
@@ -236,11 +251,11 @@ namespace kwk
       detail::constexpr_for<dz>
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
-          storage_[I] = other.template get<I>();
+          as_array()[I] = other.template get<I>();
         }
       );
 
-      for(std::size_t i = dz; i < static_order;++i) storage_[i] = 1;
+      for(std::size_t i = dz; i < static_order;++i) as_array()[i] = 1;
     }
 
     //==============================================================================================
@@ -266,14 +281,14 @@ namespace kwk
       detail::constexpr_for<dz>
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
-          storage_[I] = other.template get<I>();
+          as_array()[I] = other.template get<I>();
         }
       );
 
       detail::constexpr_for<shape<OtherShaper>::static_order - dz>
       ( [&]<std::ptrdiff_t I>(std::integral_constant<std::ptrdiff_t,I> const&)
         {
-          storage_.back() *= other.template get<dz+I>();
+          as_array().back() *= other.template get<dz+I>();
         }
       );
     }
@@ -297,13 +312,13 @@ namespace kwk
     template<std::size_t I> constexpr auto get() const noexcept
     {
       if constexpr(size_map::contains(I)) return Shaper.at(I);
-      else return storage_[size_map::template locate<static_order>(I)];
+      else return as_array()[size_map::template locate<static_order>(I)];
     }
 
     /// Swap shape's contents
     void swap( shape& other ) noexcept
     {
-      storage_.swap( other.storage_ );
+      as_array().swap( other.as_array() );
     }
 
 /*
@@ -409,7 +424,8 @@ namespace kwk
       return os;
     }
 
-    storage_t storage_;
+    constexpr storage_t&        as_array() noexcept       { return static_cast<storage_t&>(*this);        }
+    constexpr storage_t const&  as_array() const noexcept { return static_cast<storage_t const&>(*this);  }
 
     private:
 

--- a/test/container/shape/properties.cpp
+++ b/test/container/shape/properties.cpp
@@ -38,11 +38,16 @@ TTS_CASE( "numel behavior on nD shape" )
   TTS_EQUAL( (kwk::of_size(1,1,1,1).numel()), 1   );
 };
 
-struct other_base { int x; };
+struct some_base  { double  y; };
+struct other_base { int     x; };
 
-struct ebo_carrier : kwk::shape<kwk::extent[42][69]>, other_base {};
+struct ebo_carrier  : kwk::shape<kwk::extent[42][69]>, some_base {};
+struct complex_ebo  : kwk::shape<kwk::extent[42][69]>, some_base, other_base {};
+struct mixed_ebo    : some_base, kwk::shape<kwk::extent[42][69]>, other_base {};
 
 TTS_CASE( "kwk::shape and Empty Base Optimisation" )
 {
-  TTS_CONSTEXPR_EQUAL( sizeof(ebo_carrier), sizeof(other_base) );
+  TTS_CONSTEXPR_EQUAL( sizeof(ebo_carrier), sizeof(some_base) );
+  TTS_CONSTEXPR_EQUAL( sizeof(complex_ebo), sizeof(some_base)*2 );
+  TTS_CONSTEXPR_EQUAL( sizeof(mixed_ebo)  , sizeof(some_base)*2 );
 };

--- a/test/container/shape/properties.cpp
+++ b/test/container/shape/properties.cpp
@@ -37,3 +37,12 @@ TTS_CASE( "numel behavior on nD shape" )
   TTS_EQUAL( (kwk::of_size(4,1,1,1).numel()), 4   );
   TTS_EQUAL( (kwk::of_size(1,1,1,1).numel()), 1   );
 };
+
+struct other_base { int x; };
+
+struct ebo_carrier : kwk::shape<kwk::extent[42][69]>, other_base {};
+
+TTS_CASE( "kwk::shape and Empty Base Optimisation" )
+{
+  TTS_CONSTEXPR_EQUAL( sizeof(ebo_carrier), sizeof(other_base) );
+};


### PR DESCRIPTION
As g++/clang and MSVC have different heuristics for EBO trigger, we make shape inherits from its storage to be sure that fully-static shape trigger EBO.