### PR TITLE
Implement as_array()

### DIFF
--- a/include/kwk/container/shape.hpp
+++ b/include/kwk/container/shape.hpp
@@ -378,6 +378,14 @@ namespace kwk
     /// Conversion to kwk::stride
     constexpr auto as_stride() const requires(static_order > 0) { return stride_type(*this); }
 
+    /// Conversion to std::array
+    constexpr auto as_array() const noexcept
+    {
+      return kumi::apply( [](auto... m) { return std::array<size_type,static_order>{m...}; }
+                        , *this
+                        );
+    }
+
     //==============================================================================================
     // Comparisons
     //==============================================================================================

--- a/test/container/shape/CMakeLists.txt
+++ b/test/container/shape/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##  SPDX-License-Identifier: MIT
 ##==================================================================================================
 set ( SOURCES
+      as_array.cpp
       as_stride.cpp
       compare.cpp
       contain.cpp

--- a/test/container/shape/as_array.cpp
+++ b/test/container/shape/as_array.cpp
@@ -1,0 +1,45 @@
+//==================================================================================================
+/*
+  KIWAKU - Containers Well Made
+  Copyright : KIWAKU Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#include "test.hpp"
+#include <kwk/container/stride.hpp>
+#include <kwk/container/shape.hpp>
+
+template<typename T, std::size_t N>
+using type = std::array<T,N>;
+
+TTS_CASE( "Convert a 1D shape to std::array" )
+{
+  using namespace kwk::literals;
+  TTS_EQUAL( kwk::of_size(9     ).as_array(), (type<int,1>{9})              );
+  TTS_EQUAL( kwk::of_size(9_c   ).as_array(), (type<unsigned char,1>{9})    );
+  TTS_EQUAL( kwk::of_size(390_c ).as_array(), (type<unsigned short,1>{390}) );
+};
+
+TTS_CASE( "Convert a 2D shape to std::array" )
+{
+  using namespace kwk::literals;
+  TTS_EQUAL( kwk::of_size(9    , 7  ).as_array(), (type<int,2>{9,7})              );
+  TTS_EQUAL( kwk::of_size(9_c  , 7_c).as_array(), (type<unsigned char,2>{9,7})    );
+  TTS_EQUAL( kwk::of_size(390_c, 7_c).as_array(), (type<unsigned short,2>{390,7}) );
+};
+
+TTS_CASE( "Convert a 3D shape to std::array" )
+{
+  using namespace kwk::literals;
+  TTS_EQUAL( kwk::of_size(9    , 7  , 11  ).as_array(), (type<int,3>{9,7,11})              );
+  TTS_EQUAL( kwk::of_size(9_c  , 7_c, 11_c).as_array(), (type<unsigned char,3>{9,7,11})    );
+  TTS_EQUAL( kwk::of_size(390_c, 7_c, 11_c).as_array(), (type<unsigned short,3>{390,7,11}) );
+};
+
+TTS_CASE( "Convert a 4D shape to std::array" )
+{
+  using namespace kwk::literals;
+  TTS_EQUAL( kwk::of_size(9    , 7  , 11  , 32        ).as_array(), (type<int,4>{9,7,11,32})            );
+  TTS_EQUAL( kwk::of_size(9_c  , 7_c, 11_c, ' '       ).as_array(), (type<unsigned char,4>{9,7,11,32})  );
+  TTS_EQUAL( kwk::of_size(390_c, 7_c, 11_c, short{32} ).as_array(), (type<unsigned short,4>{390,7,11,32}));
+};


### PR DESCRIPTION
To ease interoperability with other libraries, `kwk::shape` can now be explicitly converted to `std::array`