### PR TITLE
Implement joker-based shape constructor

### DIFF
--- a/include/kwk/container/slicers/full_slicer.hpp
+++ b/include/kwk/container/slicers/full_slicer.hpp
@@ -12,11 +12,17 @@
 #include <kwk/container/slicers/axis.hpp>
 #include <type_traits>
 #include <cstddef>
+#include <ostream>
 
 namespace kwk::detail
 {
   struct full_slicer
   {
+    friend std::ostream& operator<<(std::ostream& os, full_slicer const&)
+    {
+      return os << "_";
+    }
+
     constexpr auto operator()(std::ptrdiff_t b, std::ptrdiff_t e) const noexcept
     {
       return unit_slicer{b,e};

--- a/include/kwk/options/fixed.hpp
+++ b/include/kwk/options/fixed.hpp
@@ -14,7 +14,10 @@ namespace kwk
 {
   namespace detail
   {
+    struct full_slicer;
+
     template<typename T>      struct  to_int { using type = T; };
+    template<>                struct  to_int<full_slicer> { using type = char; };
     template<typename T, T N> struct  to_int<std::integral_constant<T,N>> { using type = T; };
     template<typename T>      using   to_int_t = typename to_int<T>::type;
 

--- a/test/container/shape/CMakeLists.txt
+++ b/test/container/shape/CMakeLists.txt
@@ -10,6 +10,7 @@ set ( SOURCES
       contain.cpp
       convert.cpp
       ctor.cpp
+      joker.cpp
       properties.cpp
       of_shape.cpp
       mixed.cpp

--- a/test/container/shape/joker.cpp
+++ b/test/container/shape/joker.cpp
@@ -1,0 +1,112 @@
+//==================================================================================================
+/*
+  KIWAKU - Containers Well Made
+  Copyright : KIWAKU Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+*/
+//==================================================================================================
+#include "kwk/detail/kumi.hpp"
+#include "test.hpp"
+#include <kwk/container/shape.hpp>
+#include <kwk/options/fixed.hpp>
+
+TTS_CASE( "1D shape constructor with joker indexes" )
+{
+  using namespace kwk::literals;
+
+  kwk::shape<kwk::_1D> d1(kwk::_);
+  TTS_EQUAL( get<0>(d1), 0);
+
+  kwk::shape<kwk::_1D> d2(3);
+  TTS_EQUAL( get<0>(d2), 3);
+
+  kwk::shape<kwk::_1D> d3(3_c);
+  TTS_EQUAL( get<0>(d3), 3);
+
+  kwk::shape<kwk::extent[3]> s1(kwk::_);
+  TTS_EQUAL( get<0>(s1), 3);
+
+  kwk::shape<kwk::extent[3]> s2(3);
+  TTS_EQUAL( get<0>(s2), 3);
+
+  kwk::shape<kwk::extent[3]> s3(3_c);
+  TTS_EQUAL( get<0>(s3), 3);
+};
+
+// ------------------- Generalized cartesian product for testing
+auto generate_dataset(auto d0, auto d1)
+{
+  return kumi::flatten(kumi::apply( [&](auto... m)
+                                      {
+                                        constexpr auto n = d0.size();
+                                        return kumi::tuple{ kumi::zip ( kumi::generate<n>(m)
+                                                                      , d1
+                                                                      )...
+                                                          };
+                                      }
+                                      , d0
+                                      )
+                      );
+}
+
+auto generate_dataset(auto d0, auto... ds)
+{
+  auto i = generate_dataset(ds...);
+  auto o = kumi::flatten(kumi::apply( [&](auto... m)
+                                            {
+                                              constexpr auto n = i.size();
+                                              return kumi::tuple{ kumi::zip( kumi::generate<n>(m)
+                                                                          , i
+                                                                          )...
+                                                                };
+                                            }
+                                        , d0
+                                        )
+                        );
+
+  return kumi::apply( [](auto... m) { return kumi::tuple{kumi::flatten(m)...}; }
+                    , o
+                    );
+}
+
+void test_sizes(auto computed, auto expected)
+{
+  kumi::for_each( [](auto e)
+                    {
+                      auto comp = kwk::of_size(get<0>(e));
+                      auto ref  = kwk::of_size(get<1>(e));
+                      TTS_EQUAL(comp, ref);
+                    }
+                  , kumi::zip(computed,expected)
+                  );
+}
+
+// ------------------- Data to reuse
+using namespace kwk::literals;
+
+// size elements
+inline auto d0 = kumi::tuple{kwk::_,3,42_c};
+inline auto d1 = kumi::tuple{kwk::_,7,61_c};
+inline auto d2 = kumi::tuple{kwk::_,5,93_c};
+inline auto d3 = kumi::tuple{kwk::_,9,33_c};
+
+// expected dimensions
+inline auto v0 = kumi::tuple{0,3,42};
+inline auto v1 = kumi::tuple{1,7,61};
+inline auto v2 = kumi::tuple{1,5,93};
+inline auto v3 = kumi::tuple{1,9,33};
+
+TTS_CASE( "2D shape constructor with joker indexes" )
+{
+  test_sizes( generate_dataset(d0,d1), generate_dataset(v0,v1));
+};
+
+TTS_CASE( "3D shape constructor with joker indexes" )
+{
+  test_sizes( generate_dataset(d0,d1,d2), generate_dataset(v0,v1, v2));
+};
+
+TTS_CASE( "4D shape constructor with joker indexes" )
+{
+  test_sizes( generate_dataset(d0,d1,d2,d3), generate_dataset(v0,v1,v2,v3));
+};

--- a/test/tts.hpp
+++ b/test/tts.hpp
@@ -558,10 +558,6 @@ namespace tts
       else              os << e;
       return os.str();
     }
-    else if constexpr( support_std_to_string<T> )
-    {
-      return std::to_string(e);
-    }
     else if constexpr( streamable<T> )
     {
       std::ostringstream os;
@@ -571,6 +567,10 @@ namespace tts
     else if constexpr( support_to_string<T> )
     {
       return to_string(e);
+    }
+    else if constexpr( support_std_to_string<T> )
+    {
+      return std::to_string(e);
     }
     else if constexpr( sequence<T> )
     {


### PR DESCRIPTION
`shape` of mixed dimensions can now be constructed using  `_` as a "joker" for pre-existing static size or default dynamic size value.

Code like:

```c++
    auto s10 = shape<extent[3][4]>(_);
    auto s11 = shape<extent[3][4]>(3);
    auto s12 = shape<extent[3][4]>(3_c);
    auto s20 = shape<extent[3][4]>(_,_);
    auto s21 = shape<extent[3][4]>(3,_);
    auto s22 = shape<extent[3][4]>(_,4_c);
    auto s23 = shape<extent[3][4]>(3_c,4);
``` 

and equivalent `of_size` now works in addition to the axis based mixed constructor
    