### PR TITLE
Make shape/stride be row major

### DIFF
--- a/include/kwk/container/container.hpp
+++ b/include/kwk/container/container.hpp
@@ -12,6 +12,7 @@
 #include <kwk/detail/container/builder.hpp>
 #include <kwk/detail/memory/block.hpp>
 #include <type_traits>
+#include <iostream>
 
 namespace kwk
 {
@@ -87,38 +88,26 @@ namespace kwk
       auto lbl    = [&]() { if constexpr(has_label) os << v.label() << ":\n"; };
 
       lbl();
-      if( v.empty() )
-      {
-        return os << spaces << "[ ]";
-      }
+      if( v.empty() ) return os << spaces << "[ ]";
 
       auto shp = v.shape();
-      if constexpr( container::static_order < 3)
-      {
-        for_each_index( [&](auto e, auto i0, auto...)
+      for_each_index( [&](auto e, auto idx)
+                      {
+                        if constexpr( container::static_order >= 3)
                         {
-                          if(i0 == 0) os << spaces << "[ ";
-                          os << e << ' ';
-                          if(i0 == get<0>(shp)-1) os << "]\n";
+                          auto panel = kumi::extract(idx,kumi::index<container::static_order-2>);
+                          if(     panel == kumi::tuple{0,0}
+                              &&  kumi::get<container::static_order-3>(idx) > 0
+                            )
+                          os << '\n';
                         }
-                      , v
-                      );
-      }
-      else
-      {
-        for_each_index( [&](auto e, auto i0, auto i1, auto i2, auto... )
-                        {
-                          if(i0 == 0)
-                          {
-                            if(i1 == 0 && i2 > 0) os << '\n';
-                            os << spaces << "[ ";
-                          }
-                          os << e << ' ';
-                          if(i0 == get<0>(shp)-1) os << "]\n";
-                        }
-                      , v
-                      );
-      }
+
+                        if(back(idx) == 0) os << spaces << "[ ";
+                        os << e << ' ';
+                        if(back(idx) == kumi::back(shp)-1) os << "]\n";
+                      }
+                    , v
+                    );
 
       return os;
     }

--- a/include/kwk/container/container.hpp
+++ b/include/kwk/container/container.hpp
@@ -12,7 +12,6 @@
 #include <kwk/detail/container/builder.hpp>
 #include <kwk/detail/memory/block.hpp>
 #include <type_traits>
-#include <iostream>
 
 namespace kwk
 {

--- a/include/kwk/detail/algorithm/for_each.hpp
+++ b/include/kwk/detail/algorithm/for_each.hpp
@@ -23,12 +23,12 @@ namespace kwk
     template<typename Func, typename Container, typename Dims>
     constexpr auto for_each(Func&& f, Container&& c, Dims const&ds)
     {
-      auto loops = kumi::fold_right ( [](auto acc, auto m)
+      auto loops = kumi::fold_left ( [](auto acc, auto m)
                                       {
                                         return [=](auto... is)
                                         {
                                           for(decltype(m) i = 0;i<m;++i)
-                                            acc(i,is...);
+                                            acc(is...,i);
                                         };
                                       }
                                     , ds
@@ -45,18 +45,18 @@ namespace kwk
     template<typename Func, typename Container, typename Dims>
     constexpr auto for_each_index(Func&& f, Container&& c, Dims const& ds)
     {
-      auto loops = kumi::fold_right ( [](auto acc, auto m)
+      auto loops = kumi::fold_left ( [](auto acc, auto m)
                                       {
                                         return [=](auto... is)
                                         {
                                           for(decltype(m) i = 0;i<m;++i)
-                                            acc(i,is...);
+                                            acc(is...,i);
                                         };
                                       }
                                     , ds
                                     , [&](auto... is)
                                       {
-                                        return KWK_FWD(f)(KWK_FWD(c)(is...), is...);
+                                        return KWK_FWD(f)(KWK_FWD(c)(is...), kumi::tie(is...));
                                       }
                                     );
       loops();

--- a/include/kwk/detail/container/accessor.hpp
+++ b/include/kwk/detail/container/accessor.hpp
@@ -33,7 +33,6 @@ namespace kwk::detail
               , stride_( pick(kwk::strides,opts) )
     {}
 
-    constexpr auto index(auto i0)     const noexcept { return i0*get<0>(stride_);       }
     constexpr auto index(auto... is)  const noexcept { return stride_.linearize(is...); }
 
     constexpr void reshape( shape_type const& s ) noexcept
@@ -128,12 +127,12 @@ namespace kwk::detail
     constexpr std::ptrdiff_t  size()  const noexcept { return shape_.numel();  }
     constexpr auto            shape() const noexcept { return shape_;          }
 
-    constexpr auto stride() const noexcept { return stride_type{fixed<1>,get<0>(shape_)}; }
+    constexpr auto stride() const noexcept { return stride_type{fixed<1>,get<1>(shape_)}; }
 
     constexpr void reshape( shape_type const& s ) { shape_ = s; }
 
     constexpr auto index(auto i0)           const noexcept { return i0; }
-    constexpr auto index(auto i0, auto i1)  const noexcept { return i0 + i1*get<0>(shape_); }
+    constexpr auto index(auto i0, auto i1)  const noexcept { return i1 + i0*get<1>(shape_); }
 
     constexpr void swap( accessor& other ) noexcept { shape_.swap( other.shape_ ); }
 

--- a/include/kwk/utility/container/stride.hpp
+++ b/include/kwk/utility/container/stride.hpp
@@ -77,11 +77,11 @@ namespace kwk
     /// Type of dimensions' size
     using size_type = typename parent::value_type;
 
-    /// Checks a @ref kwk::stride is unit - ie it's first value is statically known to be 1
+    /// Checks a @ref kwk::stride is unit - ie it's innermost value is statically known to be 1
     static constexpr auto is_unit = []()
     {
-      auto first = get<0>(parent::descriptor);
-      if constexpr(!is_joker_v<decltype(first)>) return first == 1; else return false;
+      auto innermost = kumi::back(parent::descriptor);
+      if constexpr(!is_joker_v<decltype(innermost)>) return innermost == 1; else return false;
     }();
 
     //==============================================================================================
@@ -188,11 +188,11 @@ namespace kwk
   template<auto Shape>
   constexpr auto as_stride(shape<Shape> const& s) noexcept
   {
-    constexpr auto prod = [](auto acc, auto m) { return push_back(acc, back(acc) * m); };
+    constexpr auto prod = [](auto acc, auto m) { return push_front(acc, front(acc) * m); };
 
     // Build the perfect descriptor and the suitable values tuple
-    constexpr auto d = kumi::pop_back(kumi::fold_right(prod, Shape, kumi::tuple{1}));
-              auto v = kumi::pop_back(kumi::fold_right(prod, s    , kumi::tuple{1}));
+    constexpr auto d = kumi::pop_front(kumi::fold_left(prod, Shape, kumi::tuple{1}));
+              auto v = kumi::pop_front(kumi::fold_left(prod, s    , kumi::tuple{1}));
 
     // Turn into a stride
     return kumi::apply([&](auto... e) { return stride<detail::to_combo<int>(d)>{e...}; }, v);

--- a/test/container/table/static.2d.cpp
+++ b/test/container/table/static.2d.cpp
@@ -25,7 +25,7 @@ TTS_CASE( "Build a 2D table from a C array" )
   TTS_EXPECT( v.shape().is_fully_static         );
 
   TTS_NOT_EQUAL(&ref[0], &v(0,0));
-  kwk::for_each([i=0ULL,&ref](auto e) mutable { TTS_EQUAL(e, ref[i++]) << i << "\n"; }, v);
+  kwk::for_each([i=0ULL,&ref](auto e) mutable { TTS_EQUAL(e, ref[i++]); }, v);
 
   auto w = kwk::table{ kwk::source = ref, kwk::of_size(3_c, 4_c) };
 

--- a/test/container/table/static.2d.cpp
+++ b/test/container/table/static.2d.cpp
@@ -25,7 +25,7 @@ TTS_CASE( "Build a 2D table from a C array" )
   TTS_EXPECT( v.shape().is_fully_static         );
 
   TTS_NOT_EQUAL(&ref[0], &v(0,0));
-  kwk::for_each([i=0ULL,&ref](auto e) mutable { TTS_EQUAL(e, ref[i++]); }, v);
+  kwk::for_each([i=0ULL,&ref](auto e) mutable { TTS_EQUAL(e, ref[i++]) << i << "\n"; }, v);
 
   auto w = kwk::table{ kwk::source = ref, kwk::of_size(3_c, 4_c) };
 

--- a/test/utility/stride/as_stride.cpp
+++ b/test/utility/stride/as_stride.cpp
@@ -15,12 +15,12 @@ TTS_CASE( "Convert a shapes to strides" )
   TTS_EQUAL( kwk::as_stride(kwk::shape(9)), kwk::with_strides(1_c) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(9)).is_unit, true );
 
-  TTS_EQUAL( kwk::as_stride(kwk::shape(3,4)), kwk::with_strides(1_c, 4) );
+  TTS_EQUAL( kwk::as_stride(kwk::shape(3,4)), kwk::with_strides(4,1_c) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(3,4)).is_unit, true );
 
-  TTS_EQUAL( kwk::as_stride(kwk::shape(3,5,7)), kwk::with_strides(1_c, 7, 35) );
+  TTS_EQUAL( kwk::as_stride(kwk::shape(3,5,7)), kwk::with_strides(35,7,1_c) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(3,5,7)).is_unit, true );
 
-  TTS_EQUAL( kwk::as_stride(kwk::shape(2,4,6,8)), kwk::with_strides(1_c, 8, 48, 192) );
+  TTS_EQUAL( kwk::as_stride(kwk::shape(2,4,6,8)), kwk::with_strides(192,48,8,1_c) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(2,4,6,8)).is_unit, true );
 };

--- a/test/utility/stride/as_stride.cpp
+++ b/test/utility/stride/as_stride.cpp
@@ -15,12 +15,12 @@ TTS_CASE( "Convert a shapes to strides" )
   TTS_EQUAL( kwk::as_stride(kwk::shape(9)), kwk::with_strides(1_c) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(9)).is_unit, true );
 
-  TTS_EQUAL( kwk::as_stride(kwk::shape(3,4)), kwk::with_strides(1_c, 3) );
+  TTS_EQUAL( kwk::as_stride(kwk::shape(3,4)), kwk::with_strides(1_c, 4) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(3,4)).is_unit, true );
 
-  TTS_EQUAL( kwk::as_stride(kwk::shape(3,5,7)), kwk::with_strides(1_c, 3, 15) );
+  TTS_EQUAL( kwk::as_stride(kwk::shape(3,5,7)), kwk::with_strides(1_c, 7, 35) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(3,5,7)).is_unit, true );
 
-  TTS_EQUAL( kwk::as_stride(kwk::shape(2,4,6,8)), kwk::with_strides(1_c, 2, 8, 48) );
+  TTS_EQUAL( kwk::as_stride(kwk::shape(2,4,6,8)), kwk::with_strides(1_c, 8, 48, 192) );
   TTS_EQUAL( kwk::as_stride(kwk::shape(2,4,6,8)).is_unit, true );
 };

--- a/test/utility/stride/linear_index.cpp
+++ b/test/utility/stride/linear_index.cpp
@@ -25,13 +25,13 @@ TTS_CASE( "2D behavior of linear_index" )
 {
   kwk::shape sh{4,3};
 
-  for(int i1 = 0; i1 < 3; ++i1)
+  for(int i1 = 0; i1 < 4; ++i1)
   {
-    for(int i0 = 0; i0 < 4; ++i0)
+    for(int i0 = 0; i0 < 3; ++i0)
     {
-      TTS_EQUAL((i0+4*i1), (kwk::linear_index(sh, i0, i1)) );
-      TTS_EQUAL((i0+4*i1), (kwk::linear_index(sh,kumi::tuple{i0,i1})) );
-      TTS_EQUAL((i0+4*i1), (kwk::linear_index(sh,std::array<int,2>{i0,i1})) );
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh, i0, i1)) );
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,kumi::tuple{i0,i1})) );
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,std::array<int,2>{i0,i1})) );
     }
   }
 };
@@ -40,15 +40,15 @@ TTS_CASE( "3D behavior of linear_index" )
 {
   kwk::shape sh{4,3,2};
 
-  for(int i2 = 0; i2 < 2; ++i2)
+  for(int i2 = 0; i2 < 4; ++i2)
   {
     for(int i1 = 0; i1 < 3; ++i1)
     {
-      for(int i0 = 0; i0 < 4; ++i0)
+      for(int i0 = 0; i0 < 2; ++i0)
       {
-        TTS_EQUAL((i0+4*i1+12*i2), (kwk::linear_index(sh, i0, i1, i2)) );
-        TTS_EQUAL((i0+4*i1+12*i2), (kwk::linear_index(sh,kumi::tuple{i0,i1,i2})) );
-        TTS_EQUAL((i0+4*i1+12*i2), (kwk::linear_index(sh,std::array<int,3>{i0,i1,i2})) );
+        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh, i0, i1, i2)) );
+        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh,kumi::tuple{i0,i1,i2})) );
+        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh,std::array<int,3>{i0,i1,i2})) );
       }
     }
   }
@@ -58,17 +58,17 @@ TTS_CASE( "4D behavior of linear_index" )
 {
   kwk::shape sh{5,4,3,2};
 
-  for(int i3 = 0; i3 < 2; ++i3)
+  for(int i3 = 0; i3 < 5; ++i3)
   {
-    for(int i2 = 0; i2 < 3; ++i2)
+    for(int i2 = 0; i2 < 4; ++i2)
     {
-      for(int i1 = 0; i1 < 4; ++i1)
+      for(int i1 = 0; i1 < 3; ++i1)
       {
-        for(int i0 = 0; i0 < 5; ++i0)
+        for(int i0 = 0; i0 < 2; ++i0)
         {
-          TTS_EQUAL((i0+5*i1+20*i2+60*i3), (kwk::linear_index(sh, i0, i1, i2, i3)) );
-          TTS_EQUAL((i0+5*i1+20*i2+60*i3), (kwk::linear_index(sh,kumi::tuple{i0,i1,i2,i3})) );
-          TTS_EQUAL((i0+5*i1+20*i2+60*i3), (kwk::linear_index(sh,std::array<int,4>{i0,i1,i2,i3})) );
+          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh, i0, i1, i2, i3)) );
+          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh,kumi::tuple{i0,i1,i2,i3})) );
+          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh,std::array<int,4>{i0,i1,i2,i3})) );
         }
       }
     }

--- a/test/utility/stride/linear_index.cpp
+++ b/test/utility/stride/linear_index.cpp
@@ -29,9 +29,9 @@ TTS_CASE( "2D behavior of linear_index" )
   {
     for(int i0 = 0; i0 < 3; ++i0)
     {
-      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh, i0, i1)) );
-      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,kumi::tuple{i0,i1})) );
-      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,std::array<int,2>{i0,i1})) );
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh, i1, i0)) ) << "\n";
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,kumi::tuple{i1,i0})) );
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,std::array<int,2>{i1,i0})) );
     }
   }
 };
@@ -46,9 +46,9 @@ TTS_CASE( "3D behavior of linear_index" )
     {
       for(int i0 = 0; i0 < 2; ++i0)
       {
-        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh, i0, i1, i2)) );
-        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh,kumi::tuple{i0,i1,i2})) );
-        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh,std::array<int,3>{i0,i1,i2})) );
+        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh, i2,i1,i0 )) );
+        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh,kumi::tuple{i2,i1,i0})) );
+        TTS_EQUAL((i0+2*i1+6*i2), (kwk::linear_index(sh,std::array<int,3>{i2,i1,i0})) );
       }
     }
   }
@@ -66,9 +66,9 @@ TTS_CASE( "4D behavior of linear_index" )
       {
         for(int i0 = 0; i0 < 2; ++i0)
         {
-          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh, i0, i1, i2, i3)) );
-          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh,kumi::tuple{i0,i1,i2,i3})) );
-          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh,std::array<int,4>{i0,i1,i2,i3})) );
+          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh, i3,i2,i1,i0 )) );
+          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh,kumi::tuple{i3,i2,i1,i0})) );
+          TTS_EQUAL((i0+2*i1+6*i2+24*i3), (kwk::linear_index(sh,std::array<int,4>{i3,i2,i1,i0})) );
         }
       }
     }

--- a/test/utility/stride/linear_index.cpp
+++ b/test/utility/stride/linear_index.cpp
@@ -29,7 +29,7 @@ TTS_CASE( "2D behavior of linear_index" )
   {
     for(int i0 = 0; i0 < 3; ++i0)
     {
-      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh, i1, i0)) ) << "\n";
+      TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh, i1, i0)) );
       TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,kumi::tuple{i1,i0})) );
       TTS_EQUAL((i0+3*i1), (kwk::linear_index(sh,std::array<int,2>{i1,i0})) );
     }

--- a/test/utility/stride/with_strides.cpp
+++ b/test/utility/stride/with_strides.cpp
@@ -8,6 +8,7 @@
 #include "test.hpp"
 #include <kwk/utility/container/stride.hpp>
 #include <kwk/utility/fixed.hpp>
+#include <type_traits>
 
 using namespace kwk::literals;
 auto in = kumi::tuple{1_c,2_c,9};
@@ -21,7 +22,7 @@ void test_strides(auto values)
 
     kumi::for_each( [&](auto o, auto e) { TTS_EQUAL(o,e); }, the_stride, m );
 
-    if constexpr( std::same_as<decltype(1_c), kumi::element_t<0,decltype(m)>>)
+    if constexpr(std::same_as<decltype(1_c),std::remove_cvref_t<kumi::result::back_t<decltype(m)>>>)
     {
       TTS_CONSTEXPR_EXPECT( the_stride.is_unit );
     }


### PR DESCRIPTION
As hinted by @psiha in various issues, the default logical shape and stride order was bad.
This PR makes it so:

```c++
#include <iostream>
#include <kwk/kwk.hpp>

int main() 
{ 
  using namespace kwk; 
  using namespace kwk::literals;  
       
  float d[5][2][2] =   
  { 
    1,2,3,4,
    5,6,7,8,
    9,10,11,12, 
    13,14,15,16,
    17,18,19,20  
  };    
          
  auto t = view{source = d, of_size(5,2,2)};

  for(int i=0;i<5;++i)  
  { 
    for(int j=0;j<2;++j)
    {
      for(int k=0;k<2;++k)
        std::cout << (&d[i][j][k] == &t(i,j,k))<< " ";
      std::cout << "\n";
    }  
    std::cout << "\n";
  }
}                       
```

work as intended. 

This is of course a MAJOR ABI BREAK.
